### PR TITLE
Add pre-commit-ci bot to approved list

### DIFF
--- a/approvedBots.csv
+++ b/approvedBots.csv
@@ -101,3 +101,4 @@ opbld27
 opbld15
 opbld16
 opbld17
+pre-commit-ci[bot]


### PR DESCRIPTION
Hi! I would like to have the `pre-commit-ci` bot approved. Example:
- https://github.com/microsoft/hi-ml/pull/593#issue-1362537672

I guess the format would be `pre-commit-ci[bot]`, but I'm not sure.

Please let me know if you need any further information.