### PR TITLE
Add NuGet team bot

### DIFF
--- a/approvedBots.csv
+++ b/approvedBots.csv
@@ -102,3 +102,4 @@ opbld15
 opbld16
 opbld17
 cae-pr-creator[bot]
+nugetteambot[bot]


### PR DESCRIPTION
We have already added it to our org github config: https://github.com/NuGet/.github/commit/b8044a23ab0457143feae84d102baae5e496302e

Currently the bot's pull requests require a CLA to be signed: https://github.com/NuGet/NuGet.Client/pull/6479