### PR TITLE
Approve aiagentpool-mrbot[bot]

### DIFF
--- a/approvedBots.csv
+++ b/approvedBots.csv
@@ -1,105 +1,106 @@
 dependabot[bot]
 vedantmgoyal2009[bot]
-greenkeeper[bot]
+greenke eper[bot]
 dotnet-maestro[bot]
-dependabot-preview[bot]
+dependabot-prev iew[bot]
 openapi-sdkautomation[bot]
-github-actions[bot]
+github-ac tions[bot]
 content-assistant[bot]
-reunion-maestro[bot]
+reunion-mae stro[bot]
 renovate[bot]
-microsoft-github-policy-service[bot]
+microsoft-github-poli cy-service[bot]
 msftbot[bot]
-azure-pipelines[bot]
+azure-pipelines[ bot]
 prmerger-test[bot]
-learn-build-service-test[bot]
+learn-build-service-t est[bot]
 learn-build-service-ppe[bot]
-learn-build-service-prod[bot]
+learn-b uild-service-prod[bot]
 CBL-Mariner-Bot
-pbicvbot
+pbicvb ot
 acomghbot
 azuresdkciprbot
-dotnet-corert-bot
+dotnet-corert-bo t
 iotgwbot
 LordBobbot
 qa-bot
 winobjc-bot
-mukaibot
+muka ibot
 edtbot
 tecbot
 nzspambot
 SoundBot
-dn-helix-agents-bot
+dn-heli x-agents-bot
 wslbot
 dotnet-bot
 benrobot
-typescript-bot
+types cript-bot
 ansibleazurebot
 wdkbot
 deanbot
-OutlookBot
+Outl ookBot
 ALGitHubBot
 blackrobot
-azure-pipelines-bot
+azure-pipelines -bot
 uefibot
 flinchbot
 MicrosoftIssueBot
-agentoffline-bot
+agen toffline-bot
 officedocsbot
 vswdbot
-thisisnotarobot
+thisisnota robot
 coreosbot
 McCoyBot
 audevbot
-csd-automationbot
+csd-automat ionbot
 ascforiotbot
 rnbot
-MixedRealitySpectatorViewBot
+MixedRealitySpectat orViewBot
 UI-Fabric-RN-Bot
-dotnet-maestro-bot
+dotnet-maestro-bot 
 anton-bot
 WorkingRobot
 azclibot
-dotnet-docker-bot
+dotnet-docke r-bot
 rnsdkbot
 jenfoxbot
 MSLearnBot
-wingetbot
+wingetbot 
 azure-powershell-bot
 ninjarobot
 leha-bot
-sasabot
+sas abot
 akri-bot
 dokku-bot
 testplatform-bot
-microsoft-golang-bot
+micr osoft-golang-bot
 RunTheBot
 julien-lebot
-zangobot
+zango bot
 meo-autobot
 acomghbot
 upgradvisor-bot
-oberonbot
+obe ronbot
 PylanceBot
 nfbot
 pulumi-bot
 engelbot
-inclusive-coding-bot
+i nclusive-coding-bot
 dotnet-winget-bot
-trustedroots-bot
+trusted roots-bot
 polymcbot
 LizardByte-bot
-goodboyrobot
+goodboyrob ot
 ActivityWatchBot
 OhMyGuus-Bot
-podman-desktop-bot
+podman-deskt op-bot
 liurunliang-bot
 playwrightmachine
-openpublishbuild
+open publishbuild
 AzureRestAPISpecReview
 opbld27
-opbld15
+o pbld15
 opbld16
 opbld17
 cae-pr-creator[bot]
-nugetteambot[bot]
+nu getteambot[bot]
+  aiagentpool-mrbot[bot]

--- a/approvedBots.csv
+++ b/approvedBots.csv
@@ -1,106 +1,106 @@
 dependabot[bot]
 vedantmgoyal2009[bot]
-greenke eper[bot]
+greenkeeper[bot]
 dotnet-maestro[bot]
-dependabot-prev iew[bot]
+dependabot-preview[bot]
 openapi-sdkautomation[bot]
-github-ac tions[bot]
+github-actions[bot]
 content-assistant[bot]
-reunion-mae stro[bot]
+reunion-maestro[bot]
 renovate[bot]
-microsoft-github-poli cy-service[bot]
+microsoft-github-policy-service[bot]
 msftbot[bot]
-azure-pipelines[ bot]
+azure-pipelines[bot]
 prmerger-test[bot]
-learn-build-service-t est[bot]
+learn-build-service-test[bot]
 learn-build-service-ppe[bot]
-learn-b uild-service-prod[bot]
+learn-build-service-prod[bot]
 CBL-Mariner-Bot
-pbicvb ot
+pbicvbot
 acomghbot
 azuresdkciprbot
-dotnet-corert-bo t
+dotnet-corert-bot
 iotgwbot
 LordBobbot
 qa-bot
 winobjc-bot
-muka ibot
+mukaibot
 edtbot
 tecbot
 nzspambot
 SoundBot
-dn-heli x-agents-bot
+dn-helix-agents-bot
 wslbot
 dotnet-bot
 benrobot
-types cript-bot
+typescript-bot
 ansibleazurebot
 wdkbot
 deanbot
-Outl ookBot
+OutlookBot
 ALGitHubBot
 blackrobot
-azure-pipelines -bot
+azure-pipelines-bot
 uefibot
 flinchbot
 MicrosoftIssueBot
-agen toffline-bot
+agentoffline-bot
 officedocsbot
 vswdbot
-thisisnota robot
+thisisnotarobot
 coreosbot
 McCoyBot
 audevbot
-csd-automat ionbot
+csd-automationbot
 ascforiotbot
 rnbot
-MixedRealitySpectat orViewBot
+MixedRealitySpectatorViewBot
 UI-Fabric-RN-Bot
-dotnet-maestro-bot 
+dotnet-maestro-bot
 anton-bot
 WorkingRobot
 azclibot
-dotnet-docke r-bot
+dotnet-docker-bot
 rnsdkbot
 jenfoxbot
 MSLearnBot
-wingetbot 
+wingetbot
 azure-powershell-bot
 ninjarobot
 leha-bot
-sas abot
+sasabot
 akri-bot
 dokku-bot
 testplatform-bot
-micr osoft-golang-bot
+microsoft-golang-bot
 RunTheBot
 julien-lebot
-zango bot
+zangobot
 meo-autobot
 acomghbot
 upgradvisor-bot
-obe ronbot
+oberonbot
 PylanceBot
 nfbot
 pulumi-bot
 engelbot
-i nclusive-coding-bot
+inclusive-coding-bot
 dotnet-winget-bot
-trusted roots-bot
+trustedroots-bot
 polymcbot
 LizardByte-bot
-goodboyrob ot
+goodboyrobot
 ActivityWatchBot
 OhMyGuus-Bot
-podman-deskt op-bot
+podman-desktop-bot
 liurunliang-bot
 playwrightmachine
-open publishbuild
+openpublishbuild
 AzureRestAPISpecReview
 opbld27
-o pbld15
+opbld15
 opbld16
 opbld17
 cae-pr-creator[bot]
-nu getteambot[bot]
-  aiagentpool-mrbot[bot]
+nugetteambot[bot]
+aiagentpool-mrbot[bot]


### PR DESCRIPTION
Adds `aiagentpool-mrbot[bot]` to the approved bots list.

**What it is.** A GitHub App used by an internal Azure Messaging engineering automation pool. It runs build-failure triage against Azure repos — investigating gated-build failures, preparing fixes, and opening the resulting pull requests under its own identity rather than a maintainer's personal account.

**Why the approval is needed.** Its pull requests are currently blocked by the CLA check (for example `Azure/vld#65`), which asks the bot itself to accept the agreement. Neither reply is truthful for an automated identity: the default asserts sole personal ownership of the intellectual property, and a company reply would have automation entering a contributor agreement on Microsoft's behalf. Per the CLA documentation, pre-approving the bot here is the intended mechanism.

**Provenance.** The App is registered and owned by a Microsoft employee (@mattdurak) and installed only on Azure organization repositories. Everything it contributes is Microsoft work product produced under employment, and every pull request it opens is reviewed by Microsoft engineers before merge — in these repos it is additionally gated to require two distinct human approvals, since the bot authoring a change means the usual human author is absent.